### PR TITLE
improve #words_starting_with_un_and_ending_with_ing spec to address false positives

### DIFF
--- a/lib/regex_lab.rb
+++ b/lib/regex_lab.rb
@@ -1,21 +1,19 @@
-require 'pry'
-
 def starts_with_a_vowel?(word)
-  !!word.match(/\A[aeiou]/i)
+
 end
 
 def words_starting_with_un_and_ending_with_ing(text)
-  text.scan(/\bun\w+ing/)
+
 end
 
 def words_five_letters_long(text)
-  text.scan(/\b\w{5}\b/)
+
 end
 
 def first_word_capitalized_and_ends_with_punctuation?(text)
-  !!text.match(/\A[A-Z].+[?!.]\z/)
+
 end
 
 def valid_phone_number?(phone)
-  !!phone.match(/\A\({0,1}\d{3}[\)-.\s]{0,1}\d{3}[\)-.\s]{0,1}\d{4}\z/)
+
 end

--- a/lib/regex_lab.rb
+++ b/lib/regex_lab.rb
@@ -1,19 +1,21 @@
-def starts_with_a_vowel?(word)
+require 'pry'
 
+def starts_with_a_vowel?(word)
+  !!word.match(/\A[aeiou]/i)
 end
 
 def words_starting_with_un_and_ending_with_ing(text)
-
+  text.scan(/\bun\w+ing/)
 end
 
 def words_five_letters_long(text)
-
+  text.scan(/\b\w{5}\b/)
 end
 
 def first_word_capitalized_and_ends_with_punctuation?(text)
-
+  !!text.match(/\A[A-Z].+[?!.]\z/)
 end
 
 def valid_phone_number?(phone)
-
+  !!phone.match(/\A\({0,1}\d{3}[\)-.\s]{0,1}\d{3}[\)-.\s]{0,1}\d{4}\z/)
 end

--- a/spec/regex_lab_spec.rb
+++ b/spec/regex_lab_spec.rb
@@ -22,11 +22,14 @@ describe "Working with Regular expressions" do
 
   describe "#words_starting_with_un_and_ending_with_ing" do
     it "returns an array with the words starting with 'un' and ending with 'ing'" do
-      words_string = "unassuming ambiguous understanding pomp circumstance uninteresting uncompromising grouchy corollary"
+      words_string = "unassuming ambiguous understanding pomp circumstance uninteresting uncompromising grouchy corollary interesting unintended scrunching"
       
       expect(words_starting_with_un_and_ending_with_ing(words_string).count).to eq(4)
       expect(words_starting_with_un_and_ending_with_ing(words_string)).to include("understanding")
       expect(words_starting_with_un_and_ending_with_ing(words_string)).not_to include("pomp")
+      expect(words_starting_with_un_and_ending_with_ing(words_string)).not_to include("interesting")
+      expect(words_starting_with_un_and_ending_with_ing(words_string)).not_to include("unintended")
+      expect(words_starting_with_un_and_ending_with_ing(words_string)).not_to include("scrunching")
     end
   end
 


### PR DESCRIPTION
Added to `#words_starting_with_un_and_ending_with_ing` spec to account for the three following false positives:

+ `text.scan(/un\w+/)`
+ `text.scan(/\w+ing/)`
+ `text.scan(/un\w+ing/)`

The current provided solution, `text.scan(/un\w+ing\b/)`, should also be altered to `text.scan(/\bun\w+ing\b/)`, because the former will match **"un"** even when it doesn't begin a word.

Also, the following portion of the test seems arbitrary:
`expect(words_starting_with_un_and_ending_with_ing(words_string).count).to eq(4)`