### PR TITLE
fixes #79 #valid_phone_number? test

### DIFF
--- a/spec/regex_lab_spec.rb
+++ b/spec/regex_lab_spec.rb
@@ -63,16 +63,12 @@ describe "Working with Regular expressions" do
   describe "#valid_phone_number?" do
     it "returns true for valid phone numbers, regardless of formatting" do
       valid_numbers = ["2438894546", "(718)891-1313", "234 435 9978", "(800)4261134"]
-      valid_numbers.each do |number|
-        expect(valid_phone_number?(number)).to be(true)
-      end
+      expect(valid_numbers.all? { |number| valid_phone_number?(number) }).to be(true)
     end
 
     it "returns false for invalid phone numbers, regardless of formatting" do
       valid_numbers = ["28894546", "(718)891-13135", "234 43 9978", "(800)IloveNY"]
-      valid_numbers.each do |number|
-        expect(valid_phone_number?(number)).to be(false)
-      end
+      expect(valid_numbers.all? { |number| valid_phone_number?(number) }).to be(false)
     end
   end
 


### PR DESCRIPTION
The current test iterates over an array of phone numbers and expects calls to `#valid_phone_number` with each number to return `false`. The problem with this is that there are valid phone numbers in the array which would cause the test fail.
It should really be checking if any of the numbers in the array is invalid. So `valid_numbers.all?` instead of `valid_numbers.each` should be used.