### PR TITLE
fix solution regexes

### DIFF
--- a/lib/regex_lab.rb
+++ b/lib/regex_lab.rb
@@ -1,11 +1,11 @@
 require 'pry'
 
 def starts_with_a_vowel?(word)
-  word.match(/^[aeiouAEIOU]\w+/) ? true : false
+  word.match(/^[aeiouAEIOU]\w*/) ? true : false
 end
 
 def words_starting_with_un_and_ending_with_ing(text)
-  text.scan(/un\w+ing\b/)
+  text.scan(/\bun\w+ing\b/)
 end
 
 def words_five_letters_long(text)
@@ -13,7 +13,7 @@ def words_five_letters_long(text)
 end
 
 def first_word_capitalized_and_ends_with_punctuation?(text)
-  text.match(/^[A-Z].+[\.!?]$/) ? true : false
+  text.match(/^[A-Z].*[\.!?]$/) ? true : false
 end
 
 def valid_phone_number?(phone)


### PR DESCRIPTION
In `starts_with_a`, should end with `\w*` instead of `\w+` to account for single-letter words, such as "a."

In `words_starting_with_un_and_ending_with_ing`, should to add `\b` at beginning of regex, or else could match even if "un..." comes up in the middle of a word, e.g. with "reuniting."

Again, in `first_word_capitalized_and_ends_with_punctuation?`, should replace `.+` with `.*` to account for single-word sentences.