### PR TITLE
Updated Solution to the valid_phone_number? Method

### DIFF
--- a/lib/regex_lab.rb
+++ b/lib/regex_lab.rb
@@ -1,19 +1,19 @@
 def starts_with_a_vowel?(word)
-
+  word.match(/^[aeiouAEIOU]/) ? true : false
 end
 
 def words_starting_with_un_and_ending_with_ing(text)
-
+  text.scan(/\bun\S*ing\b/)
 end
 
 def words_five_letters_long(text)
-
+  text.scan(/\b\S{5}\b/)
 end
 
 def first_word_capitalized_and_ends_with_punctuation?(text)
-
+  text.match(/^[A-Z].*[\.\!\?]$/) ? true : false
 end
 
 def valid_phone_number?(phone)
-
+  phone.match(/\(*\d{3}[\)\s]*\d{3}[\-\s]*\d{4}/) ? true : false
 end

--- a/lib/regex_lab.rb
+++ b/lib/regex_lab.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 def starts_with_a_vowel?(word)
   word.match(/^[aeiouAEIOU]/) ? true : false
 end

--- a/lib/regex_lab.rb
+++ b/lib/regex_lab.rb
@@ -1,19 +1,21 @@
+require 'pry'
+
 def starts_with_a_vowel?(word)
   word.match(/^[aeiouAEIOU]/) ? true : false
 end
 
 def words_starting_with_un_and_ending_with_ing(text)
-  text.scan(/\bun\S*ing\b/)
+  text.scan(/\bun\w*ing\b/)
 end
 
 def words_five_letters_long(text)
-  text.scan(/\b\S{5}\b/)
+  text.scan(/\b\w{5}\b/)
 end
 
 def first_word_capitalized_and_ends_with_punctuation?(text)
-  text.match(/^[A-Z].*[\.\!\?]$/) ? true : false
+  text.match(/^[A-Z].+[\.!?]$/) ? true : false
 end
 
 def valid_phone_number?(phone)
-  phone.match(/\(*\d{3}[\)\s]*\d{3}[\-\s]*\d{4}/) ? true : false
+  phone.match(/\(*\d{3}[\)\s]*\d{3}[-\s]*\d{4}/) ? true : false
 end

--- a/spec/regex_lab_spec.rb
+++ b/spec/regex_lab_spec.rb
@@ -63,16 +63,12 @@ describe "Working with Regular expressions" do
   describe "#valid_phone_number?" do
     it "returns true for valid phone numbers, regardless of formatting" do
       valid_numbers = ["2438894546", "(718)891-1313", "234 435 9978", "(800)4261134"]
-      valid_numbers.each do |number|
-        expect(valid_phone_number?(number)).to be(true)
-      end
+      expect(valid_numbers.all? { |number| valid_phone_number?(number) }).to be(true)
     end
 
     it "returns false for invalid phone numbers, regardless of formatting" do
       valid_numbers = ["28894546", "(718)891-13135", "234 43 9978", "(800)IloveNY"]
-      valid_numbers.each do |number|
-        expect(valid_phone_number?(number)).to be(false)
-      end
+      expect(valid_numbers.all? { |number| valid_phone_number?(number) }).to be(false)
     end
   end
 

--- a/spec/regex_lab_spec.rb
+++ b/spec/regex_lab_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "Working with Regular expressions" do
-  describe "#{}starts_with_a_vowel?" do
+  describe "#starts_with_a_vowel?" do
     it "returns true for words starting with a vowel" do
       match = %w{ afoot Excellent incredible Absolute unreal Inconceivable octopus }
 


### PR DESCRIPTION
This commit includes a significantly shorter solution to the valid_phone_number? method that either recognizes or ignores additional characters in the phone number format by using the "zero or many" character *. It looks for 3 digits, 3 digits, and 4 digits while simply skipping over any parentheses, dashes, or spaces. The current solution attempts to check different formats with a series of expressions that are OR'ed together, resulting in a longer solution.